### PR TITLE
Issue-4 - Remove linebreaks from password (needed for pws coming from…

### DIFF
--- a/tasks/02_fetchjdk.yml
+++ b/tasks/02_fetchjdk.yml
@@ -14,7 +14,7 @@
       get_url:
         url:      '{{ oraclejdk_url }}'
         url_username: '{{ oraclejdk_url_user }}'
-        url_password: '{{ oraclejdk_url_pass }}'
+        url_password: "{{ oraclejdk_url_pass | replace('\n','') }}"
         headers:  '{{ oraclejdk_cookie }}'
         checksum: '{{ oraclejdk_checksum }}'
         dest:     '{{ oraclejdk_dl_dir }}/'


### PR DESCRIPTION
Automatically remove linebreaks from url password. Otherwise the plays may fail when the pw is coming from vault and has an additional unwanted \n at the end.